### PR TITLE
Update documentation to explain the GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-The `GITHUB_TOKEN` secret is [automatically managed by GitHub](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret). You do not have to manually create this secret. This automatic token is [scoped only to the repository that is currently running the action.](https://help.github.com/en/articles/virtual-environments-for-github-actions#token-permissions).
+The `GITHUB_TOKEN` secret is [automatically managed by GitHub](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret). You do not have to manually create this secret. This automatic token is [scoped only to the repository that is currently running the action.](https://help.github.com/en/articles/virtual-environments-for-github-actions#token-permissions)
 
 ## Links and resources
 


### PR DESCRIPTION
Update documentation to explain that the `GITHUB_TOKEN` is automatically issued by GitHub actions. 

Closes #8 