### PR TITLE
Expose significantCompressionPercent for user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ webp:
   quality: 80
 ignorePaths:
   - "node_modules/**"
+significantCompressionPercent: 1
 ```
 
 - The above configuation is what `image-actions` uses by default
 - The `jpeg`, `png` and `webp` config keys will be delivered directly into [sharp’s](http://sharp.pixelplumbing.com) `toFormat`. ([JPEG options](http://sharp.pixelplumbing.com/en/stable/api-output/#jpeg), [PNG options](http://sharp.pixelplumbing.com/en/stable/api-output/#png), [Webp options](http://sharp.pixelplumbing.com/en/stable/api-output/#webp))
 - `ignorePaths` allows for path globbing [see the glob package for more details](https://www.npmjs.com/package/glob)
+- Images with a compression yield less than `significantCompressionPercent` will not be committed
 
 ## Links and Resources
 

--- a/__tests__/image-processing_test.js
+++ b/__tests__/image-processing_test.js
@@ -66,3 +66,36 @@ test("returns images with stats", async () => {
     }
   ]);
 });
+
+test("obeys significantCompressionPercent config", async () => {
+  const results = await imageProcessing({
+    significantCompressionPercent: 63
+  });
+
+  expect(results.images).toEqual([
+    {
+      afterStats: 3361,
+      beforeStats: 8914,
+      compressionWasSignificant: false,
+      name: "icon.png",
+      path: "__tests__/test-images/icon.png",
+      percentChange: -62.29526587390622
+    },
+    {
+      afterStats: 3361,
+      beforeStats: 3361,
+      compressionWasSignificant: false,
+      name: "optimised-image.png",
+      path: "__tests__/test-images/optimised-image.png",
+      percentChange: 0
+    },
+    {
+      afterStats: 485759,
+      beforeStats: 468895,
+      compressionWasSignificant: false,
+      name: "roo.jpg",
+      path: "__tests__/test-images/roo.jpg",
+      percentChange: 3.596540803378147
+    }
+  ]);
+});

--- a/src/config.js
+++ b/src/config.js
@@ -19,7 +19,8 @@ const getConfig = async () => {
     jpeg: { quality: 80 },
     png: { quality: 80 },
     webp: { quality: 80 },
-    ignorePaths: ["node_modules/**"]
+    ignorePaths: ["node_modules/**"],
+    significantCompressionPercent: 1
   };
 
   const ymlConfig = await getYamlConfig();

--- a/src/image-processing.js
+++ b/src/image-processing.js
@@ -11,8 +11,8 @@ const {
   EXTENSION_TO_SHARP_FORMAT_MAPPING
 } = require("./constants");
 
-const processImages = async () => {
-  const config = await getConfig();
+const processImages = async (configOverride = {}) => {
+  const config = { ...(await getConfig()), ...configOverride };
   const imagePaths = await glob(`${REPO_DIRECTORY}/**/*.{jpg,png,webp}`, {
     ignore: config.ignorePaths.map(p => path.resolve(REPO_DIRECTORY, p)),
     nodir: true
@@ -44,7 +44,7 @@ const processImages = async () => {
     const percentChange = (afterStats / beforeStats) * 100 - 100;
 
     // Add a flag to tell if the optimisation was worthwhile
-    const compressionWasSignificant = percentChange < -1;
+    const compressionWasSignificant = percentChange < (config.significantCompressionPercent * -1);
 
     images.push({
       name,


### PR DESCRIPTION
We'd like to be able to configure the percentage compression that's considered significant to avoid some images being double-compressed on subsequent PRs.