### PR TITLE
Add an "Advanced" configuration method

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,29 @@ Change the configuration options by adding arguments to the action:
     pngQuality: '80'
     webpQuality: '80'
     ignorePaths: '["node_modules/**", "build"]'
+    configFile: '.github/workflow/image-config.json'
 ```
 
 Previous versions of image-actions used `.github/config/image-actions.yml` for configuration. 
 If you're still using that configuration method we suggest that you update it.
 
 - The above configuration is what `image-actions` uses by default
-- The `jpegQuality`, `pngQuality` and `webpQuality` config keys will be delivered directly into [sharp’s](http://sharp.pixelplumbing.com) `toFormat`. ([JPEG options](http://sharp.pixelplumbing.com/en/stable/api-output/#jpeg), [PNG options](http://sharp.pixelplumbing.com/en/stable/api-output/#png), [Webp options](http://sharp.pixelplumbing.com/en/stable/api-output/#webp))
+- The `jpegQuality`, `pngQuality` and `webpQuality` config keys will be delivered directly into [sharp’s](http://sharp.pixelplumbing.com) `toFormat`.
 - `ignorePaths` allows for path globbing [see the glob package for more details](https://www.npmjs.com/package/glob)
+- `configFile` allows you to specify a JSON file containing more advanced options that will be delivered directly into [sharp’s](http://sharp.pixelplumbing.com) `toFormat`. ([JPEG options](http://sharp.pixelplumbing.com/en/stable/api-output/#jpeg), [PNG options](http://sharp.pixelplumbing.com/en/stable/api-output/#png), [Webp options](http://sharp.pixelplumbing.com/en/stable/api-output/#webp))
+
+  ```JSON
+  {
+    "jpeg": {
+      "quality": 90,
+      "progressive": true
+    },
+    "png": {
+      "quality": 80
+    }
+  }
+  ```
+
 
 ## Running the action only when images are changed
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ Change the configuration options by adding arguments to the action:
   uses: calibreapp/image-actions@master
   with:
     githubToken: ${{ secrets.GITHUB_TOKEN }}
-    jpegQuality: "80"
-    pngQuality: "80"
-    webpQuality: "80"
-    ignorePaths: "node_modules/**,build"
-    # No spaces allowed
+    jpegQuality: '80'
+    pngQuality: '80'
+    webpQuality: '80'
+    ignorePaths: '["node_modules/**", "build"]'
 ```
 
 Previous versions of image-actions used .github/config/image-actions.yml for configuration. 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,10 @@ inputs:
     required: false
     default: '["node_modules/**"]'
 
+  configFile:
+    description: 'JSON file containing advanced configuration'
+    required: false
+
 runs:
   using: 'docker'
   image: 'docker://calibreapp/github-image-actions' 

--- a/action.yml
+++ b/action.yml
@@ -1,36 +1,36 @@
-name: "Image Actions"
-author: "Calibre"
-description: "Compresses Images for the Web"
+name: 'Image Actions'
+author: 'Calibre'
+description: 'Compresses Images for the Web'
 
 inputs:
   githubToken:
-    description: "GitHub Token"
+    description: 'GitHub Token'
     required: true
 
   jpegQuality:
-    description: "JPEG quality level"
+    description: 'JPEG quality level'
     required: false
-    default: "80"
+    default: '80'
 
   pngQuality:
-    description: "PNG quality level"
+    description: 'PNG quality level'
     required: false
-    default: "80"
+    default: '80'
 
   webpQuality:
-    description: "WEBP quality level"
+    description: 'WEBP quality level'
     required: false
-    default: "80"
+    default: '80'
 
   ignorePaths:
-    description: "Paths to ignore during search"
+    description: 'Paths to ignore during search'
     required: false
-    default: "node_modules/**"
+    default: '["node_modules/**"]'
 
 runs:
-  using: "docker"
-  image: "docker://calibreapp/github-image-actions" 
+  using: 'docker'
+  image: 'docker://calibreapp/github-image-actions' 
 
 branding:
-  icon: "image"
-  color: "green"
+  icon: 'image'
+  color: 'green'

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,7 @@ const fs = require("fs").promises;
 const yaml = require("js-yaml");
 
 const { CONFIG_PATH,
+  CONFIG_FILE,
   JPEG_QUALITY,
   PNG_QUALITY,
   WEBP_QUALITY,
@@ -18,6 +19,15 @@ const getYamlConfig = async () => {
   }
 };
 
+const getJsonConfig = async () => {
+  try {
+    const text = await fs.readFile(CONFIG_FILE);
+    return JSON.parse(text);
+  } catch (err) {
+    return undefined;
+  }
+};
+
 const getConfig = async () => {
   const defaultConfig = {
     jpeg: { quality: JPEG_QUALITY },
@@ -27,14 +37,17 @@ const getConfig = async () => {
   };
 
   const ymlConfig = await getYamlConfig();
-  const config = ymlConfig
+  const jsonConfig = await getJsonConfig();
+  const config = jsonConfig
+    ? Object.assign(defaultConfig, jsonConfig)
+    : ymlConfig
     ? Object.assign(defaultConfig, ymlConfig)
     : defaultConfig;
 
   console.log(
     "->> Checking for config at",
     CONFIG_PATH,
-    !ymlConfig ? "Not found" : "Found!"
+    !jsonConfig ? !ymlConfig ? "Not found" : "Found!" : "Found!"
   );
 
   if (ymlConfig) {

--- a/src/config.js
+++ b/src/config.js
@@ -46,7 +46,7 @@ const getConfig = async () => {
 
   console.log(
     "->> Checking for config at",
-    CONFIG_PATH,
+    process.env["INPUT_CONFIGFILE"] ? CONFIG_FILE : CONFIG_PATH,
     !jsonConfig ? !ymlConfig ? "Not found" : "Found!" : "Found!"
   );
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -30,6 +30,11 @@ const CONFIG_PATH = path.join(
   ".github/calibre/image-actions.yml"
 );
 
+const CONFIG_FILE = path.join(
+  REPO_DIRECTORY,
+  process.env["INPUT_CONFIGFILE"]
+);
+
 const EXTENSION_TO_SHARP_FORMAT_MAPPING = {
   ".png": "png",
   ".jpeg": "jpeg",

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,7 +12,7 @@ const REPO_DIRECTORY = process.env["GITHUB_WORKSPACE"];
 const JPEG_QUALITY = parseInt(process.env["INPUT_JPEGQUALITY"]) || 80;
 const PNG_QUALITY = parseInt(process.env["INPUT_PNGQUALITY"]) || 80;
 const WEBP_QUALITY = parseInt(process.env["INPUT_WEBPQUALITY"]) || 80;
-const IGNORE_PATHS = process.env["INPUT_IGNOREPATHS"].split(",") || ["node_modules/**"];
+const IGNORE_PATHS = JSON.parse(process.env["INPUT_IGNOREPATHS"] || '["node_modules/**"]');
 
 const COMMITTER = {
   name: "Calibre",

--- a/src/image-processing.js
+++ b/src/image-processing.js
@@ -8,13 +8,14 @@ const getConfig = require("./config");
 
 const {
   REPO_DIRECTORY,
-  EXTENSION_TO_SHARP_FORMAT_MAPPING
+  EXTENSION_TO_SHARP_FORMAT_MAPPING,
+  IGNORE_PATHS
 } = require("./constants");
 
 const processImages = async () => {
   const config = await getConfig();
   const imagePaths = await glob(`${REPO_DIRECTORY}/**/*.{jpg,png,webp}`, {
-    ignore: config.ignorePaths.map(p => path.resolve(REPO_DIRECTORY, p)),
+    ignore: (config["ignorePaths"] || IGNORE_PATHS).map(p => path.resolve(REPO_DIRECTORY, p)),
     nodir: true
   });
 


### PR DESCRIPTION
Since #29, the original YAML config method became no longer supported, the problem with this, is that it's no longer documented how configure any advanced imageSharp settings (i.e. progressive JPEGs, etc.).

A simple cure for this would be to add an input to `action.yml` for progressive JPEGs. However, this is not practical in the long term, as we would basically need to add an input for each option, which is a bad idea for various reasons, not limited to but including, maintainability.

I think that the simplest way to do this would be to create a JSON file that contains all the config details, similar to the original YAML file, except that it only handles the actual image processing.
The format for this file would be:

```JSON
{
  "jpeg": {
    "quality": 80,
    "progressive": true
  },
  "png": {
    "quality": 80
  }
}
```

The reason why I'm picking JSON over the existing YAML format is that it would require far less code to handle than the YAML (if we were to remove support for it), and it allows us to comfortably drop the (now) deprecated YAML format.

The file would be given to the action through the `configFile` input:

```YAML
configFile:
  description: 'JSON file containing advanced configuration'
  required: false
```

Those who are still using the old YAML format would have two choices going forward:

1. Update their setup to support the new method (recommended).
2. Change their workflow file to use an older version of the [`calibreapp/github-image-actions`](https://hub.docker.com/r/calibreapp/github-image-actions) docker image (we would need to build a version of the image pre-#29 for this to work).

Note: This PR also contains #42.