### PR TITLE
Don't follow symlinks

### DIFF
--- a/src/image-processing.js
+++ b/src/image-processing.js
@@ -29,7 +29,8 @@ const processImages = async () => {
 
   const imagePaths = await glob(globPaths, {
     ignore: config.ignorePaths.map(p => path.resolve(REPO_DIRECTORY, p)),
-    nodir: true
+    nodir: true,
+    follow: false
   });
 
   const images = [];


### PR DESCRIPTION
Send the `follow: false` option to glob to stop following symlinks

Closes #19 