### PR TITLE
Fix a few minor issues in README and also add Cron option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Image Actions automatically compresses JPEG, PNG and WebP images in GitHub Pull 
   - [Installation](#installation)
   - [Configuration](#configuration)
   - [Image quality settings](#image-quality-settings)
+  - [Running just the compression](#running-just-the-compression)
+  - [Handling pull requests from forked repos](handling-pull-requests-from-forked-repos)
+  - [Compressing images on a schedule](compressing-images-on-a-schedule)
   - [Migrate legacy configuration](#migrate-legacy-configuration)
   - [Links and Resources](#links-and-resources)
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Alternatively you can run this action only for Pull Requests for the current rep
     if: github.event.pull_request.head.repo.full_name == github.repository
 ```
 
-It is also possible to run an addition instance of this action in `compressOnly` mode on pushes to master, and then raise a new pull request for any images commited from a forked repositary pull request. This is shown in the below example which uses the [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub Action to open this new Pull Request (note this only raises a Pull Request if any files are actually changed in previous steps).
+It is also possible to run an additional instance of this action in `compressOnly` mode on pushes to master, and then raise a new pull request for any images commited from a forked repositary pull request. This is shown in the below example which uses the [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub Action to open this new Pull Request (note this only raises a Pull Request if any files are actually changed in previous steps).
 
 ```yml
 name: Compress Images on Push to Master

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ jobs:
 
 ## Compressing images on a schedule
 
-Similar to above, it is also possible to run an addition instance of this action in `compressOnly` mode at specific times, and then raise a new pull request for any images compressed (again this only raises a Pull Request if any files are actually changed in previous steps).
+It is also possible to run image-actions on a reoccurring schedule. By using the `compressOnly` option,  in conjunction with [@peter-evans's](/peter-evans) [`create-pull-request`](https://github.com/peter-evans/create-pull-request) action, a new Pull Request will be raised if there are optimised images in a repository.  
 
 ```yml
 name: Compress images at 11pm and open a pull request

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Options:
 
 ## Running just the compression
 
-By default this Action will add the updated image(s) to the current pull request. It is also possible to set the `compressOnly` option to `true` to skip the commit, if you want to handle this separately - including for forks - see below.
+By default image-actions will add updated images to the current pull request. It is also possible to set the `compressOnly` option to `true` to skip the commit, if you want to handle this separately - including for forks - see below.
 
 ```yml
       - name: Compress Images

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Alternatively you can run this action only for Pull Requests for the current rep
 It is also possible to run an addition instance of this action in `compressOnly` mode on pushes to master, and then raise a new pull request for any images commited from a forked repositary pull request. This is shown in the below example which uses the [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub Action to open this new Pull Request (note this only raises a Pull Request if any files are actually changed in previous steps).
 
 ```yml
-name: Compress images on Push to Master
+name: Compress Images on Push to Master
 on:
   push:
     branches:
@@ -136,7 +136,7 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: true
-      - name: Create New Pull Request
+      - name: Create New Pull Request If Needed
         uses: peter-evans/create-pull-request@master
         with:
           title: Compressed Images
@@ -147,7 +147,7 @@ jobs:
 
 ## Compressing images on a schedule
 
-Similar to above, it is also possible to run an addition instance of this action in `compressOnly` mode at specific times, and then raise a new pull request for any images compressed.
+Similar to above, it is also possible to run an addition instance of this action in `compressOnly` mode at specific times, and then raise a new pull request for any images compressed (again this only raises a Pull Request if any files are actually changed in previous steps).
 
 ```yml
 name: Compress images at 11pm and open a pull request
@@ -168,7 +168,7 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: true
-      - name: Create New Pull Request
+      - name: Create New Pull Request If Needed
         uses: peter-evans/create-pull-request@master
         with:
           title: Compressed Images Nightly
@@ -193,7 +193,7 @@ jobs:
     Update your configuration to:
 
     ```yml
-    - name: Compress images
+    - name: Compress Images
       uses: calibreapp/image-actions@master
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Typical. You spend months on a PR, and then as soon as it's merged you spot some typos! 😞

This PR makes the following changes to the REAME:
- Updates the Table of Contents
- Changes `compressOnly` setting from `"false"` to `false` for consistency with `jpegProgressive`.
- Fixes "image" to "image(s)"
- Fixes typo "fule" to "files" and rewords it slightly for readability
- Adds section on running on schedule - fixes #70 
