### PR TITLE
ES6 Default exports

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -4,7 +4,7 @@ const {
   GITHUB_TOKEN,
   GITHUB_EVENT_NAME,
   COMPRESS_ONLY
-} = require('./dist/constants').default
+} = require('./dist/constants')
 
 const githubEvent = require('./dist/github-event').default
 const run = require('./dist/index.js').default

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -4,10 +4,10 @@ const {
   GITHUB_TOKEN,
   GITHUB_EVENT_NAME,
   COMPRESS_ONLY
-} = require('./dist/constants')
+} = require('./dist/constants').default
 
-const githubEvent = require('./dist/github-event')
-const run = require('./dist/index.js')
+const githubEvent = require('./dist/github-event').default
+const run = require('./dist/index.js').default
 
 if (!GITHUB_TOKEN) {
   console.log('::error:: You must enable the GITHUB_TOKEN secret')


### PR DESCRIPTION
Use default exports in es5 `entrypoint.js`.

Closes #73 