### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,0 +1,34 @@
+---
+name: "\U0001F41B Bug report"
+about: Found an issue? File a bug report to help us improve Image Actions for everyone.
+title: "[Bug] Bug description"
+labels: bug
+assignees: ''
+
+---
+
+👋🏻 Hi there! This template will help you file a complete bug report for Image Actions, so one of the project owners can triage and respond to it promptly. Please fill relevant sections below and feel free to delete what does not apply to the issue you are seeing (including this comment).
+
+Thank you for helping us improve Image Actions! ⚡️
+
+***
+
+## Describe the bug
+Please provide a clear and concise description of what the bug is.
+
+## How To Reproduce
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behaviour
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain the problem.
+
+## Additional context
+Add any other context about the issue you’re seeing.

--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -1,0 +1,20 @@
+---
+name: "\U0001F4A1 Feature Request"
+about: Have an idea how to make Image Actions better? We’re all ears!
+title: "[Feature Request] Feature description"
+labels: enhancement
+assignees: ''
+
+---
+
+## What problem would this feature solve?
+A clear and concise description of what the problem is. E.g. I’m always frustrated when Image Actions posts too frequently | I'd love to compress AVIF images!
+
+## Describe the solution you’d like to see
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you’ve considered
+A clear and concise description of any alternative solutions or features you’ve considered.
+
+## Additional context
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This PR:

- adds two issue templates to ensure we have the necessary context + categorisation when an issue is raised:
  - feature request template
  - bug template