### PR TITLE
feat: add support for resizing images

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,9 @@
 import { promises as fsPromises } from 'fs'
 const { readFile } = fsPromises
 import yaml from 'js-yaml'
-import { OutputOptions, PngOptions, JpegOptions, WebpOptions } from 'sharp'
+import { PngOptions, JpegOptions, WebpOptions } from 'sharp'
 
 const {
-  ImageKind,
   CONFIG_PATH,
   JPEG_QUALITY,
   JPEG_PROGRESSIVE,
@@ -14,12 +13,20 @@ const {
   COMPRESS_ONLY
 } = require('./constants')
 
+interface SizeOptions {
+  [key: string]: {
+    width?: number
+    height?: number
+  }
+}
+
 interface Config {
   compressOnly: boolean
   jpeg: JpegOptions
   png: PngOptions
   webp: WebpOptions
   ignorePaths: string[]
+  size: SizeOptions
 }
 
 // Deprecated configuration method
@@ -38,7 +45,8 @@ const getConfig = async () => {
     png: { quality: PNG_QUALITY },
     webp: { quality: WEBP_QUALITY },
     ignorePaths: IGNORE_PATHS,
-    compressOnly: COMPRESS_ONLY
+    compressOnly: COMPRESS_ONLY,
+    size: {}
   }
 
   const ymlConfig = await getYamlConfig()


### PR DESCRIPTION
👋🏻 Hi there! 

Adds a new field `size` which accepts glob patterns and defines custom width and height for the same. This can be used to target specific image or multiple images residing under a directory.

Now in config if someone adds below config: 

```
size: {
      "*/**/__tests__/test-images": { width: 200, height: 100 },
      "*/**/__tests__/test-images/icon.png": { width: 200, }
    }
```

All the files matching the glob would be resized. This can be used to target specific files, same extension files and files under a specific directory. Both width and height can be passed or either of the things can be passed. If empty object is passed it wont resize the file.

**Note** This is done using `sharp` method `resize` which have few default configs. So for eg: if width and height are defined it crops the image as the default `fit` value is `cover`. Read more here: https://sharp.pixelplumbing.com/api-resize#resize

***

## What does this PR introduce?
In a few bullet points, please describe the changes this Pull Request makes. E.g.:

- adds resizing support
- [ ] TODO readme update 

## Related issues
Closes #20 #60 
 
## Testing steps

**Test 1**

```
 size: {
      "*/**/__tests__/test-images": { width: 200, height: 100 },
}
```

All the files was resized. 

**Test 2**

```
size: {
      "*/**/__tests__/test-images/icon.png": { width: 200 },
}
```

Only icon image was resized.

cc @benschwarz @mikedijkstra 