### PR TITLE
Added a check for not printing the whole table when more than 50 images are optimized.

### DIFF
--- a/markdown-templates/inline-pr-comment-with-diff.md
+++ b/markdown-templates/inline-pr-comment-with-diff.md
@@ -2,11 +2,15 @@ Images automagically compressed by [Calibre](https://calibreapp.com)'s [image-ac
 
 Compression reduced images by <strong><%- overallPercentageSaved %>%</strong>, saving <strong><%- overallBytesSaved %></strong>.
 
+<% if(optimisedImages.length < 50) { -%>
 | Filename | Before | After | Improvement | Visual comparison |
 | -------- | ------ | ----- | ----------- | ----------------- |
 <% optimisedImages.forEach((image) => { -%>
 | <code><%- image.name %></code> | <%- image.formattedBeforeStats %> | <%- image.formattedAfterStats %> | <%- image.formattedPercentChange %> | [View diff](<%- image.diffUrl %>) |
 <% }); %>
+<% } else { %>
+<%- optimisedImages.length %> images were optimised, but the list is too long to display.
+<% } %>
 
 <% if(unoptimisedImages.length) { -%>
 <%- unoptimisedImages.length %> <%- unoptimisedImages.length > 1 ? 'images' : 'image' %> did not require optimisation.

--- a/markdown-templates/pr-comment.md
+++ b/markdown-templates/pr-comment.md
@@ -2,11 +2,15 @@ Images automagically compressed by [Calibre](https://calibreapp.com)'s [image-ac
 
 Compression reduced images by <strong><%- overallPercentageSaved %>%</strong>, saving <strong><%- overallBytesSaved %></strong>.
 
+<% if(optimisedImages.length < 50) { -%>
 | Filename | Before | After | Improvement |
 | -------- | ------ | ----- | ----------- |
 <% optimisedImages.forEach((image) => { -%>
 | <code><%- image.name %></code> | <%- image.formattedBeforeStats %> | <%- image.formattedAfterStats %> | <%- image.formattedPercentChange %> |
 <% }); %>
+<% } else { %>
+<%- optimisedImages.length %> images were optimised, but the list is too long to display.
+<% } %>
 
 <% if(unoptimisedImages.length) { -%>
 <%- unoptimisedImages.length %> <%- unoptimisedImages.length > 1 ? 'images' : 'image' %> did not require optimisation.


### PR DESCRIPTION
## What does this PR introduce?
As discussed on https://github.com/calibreapp/image-actions/issues/107, this PR added a check on the table to not print it when there are more than 50 images optimised.
Also adds the number of optimised images in case the table is not present.

Please, carefully check the markdown syntax as I was not 100% sure about it =)

## Related issues
Closes https://github.com/calibreapp/image-actions/issues/107.

## Screenshots
If this work introduces any visual changes, add screenshots to portray them.

## Reviewers
- @benschwarz
