### PR TITLE
Fix table of contents links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Image Actions offers:
 ## 🖇 Table of Contents
 
 1. [Usage](#-usage)
-2. [Configuration](#-configuration)
-3. [Migrating legacy configuration](#-migrating-legacy-configuration)
+2. [Configuration](#%EF%B8%8F-configuration)
+3. [Migrating legacy configuration](#%EF%B8%8F-migrating-legacy-configuration)
 4. [Contributing](#-contributing)
 5. [Resources](#-resources)
 6. [License](#-license)


### PR DESCRIPTION
Pretty simple PR. Just notice that some README links do not work.

## What does this PR introduce?

- Fix *Configuration* and *Migrating legacy configuration* links in README. Broken after adding emojis to titles in a070b3b609c9fd7a4fd1bd3463b31d875c190375

## Reviewers

@thefoxis