### PR TITLE
fix(entrypoint): exit(0) when pull_request.<event> is not 'synchronize' or 'opened'

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -30,7 +30,7 @@ const main = async () => {
         event.action,
         '. Wants: synchronize or opened'
       )
-      process.exit(78)
+      process.exit(0)
     }
   }
 


### PR DESCRIPTION
## What does this PR introduce?
- Action succeeds for `pull_request.<event>` different from `opened` or `synchronize`

## Related issues
- closes #84 
