### PR TITLE
Feat: Support on-premise github enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Image Actions offers:
 - Best image compression algorithms available ([mozjpeg](https://github.com/mozilla/mozjpeg) and [libvips](https://github.com/libvips/libvips))
 - [Ease of customisation](#Configuration): use default settings or adapt to your needs
 - Running on demand or schedule
+- Supports GitHub Enterprise
 
 ...and more! 
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ const GITHUB_EVENT_PATH = process.env['GITHUB_EVENT_PATH']
 const GITHUB_SHA = process.env['GITHUB_SHA']
 const GITHUB_REF = process.env['GITHUB_REF']
 const GITHUB_REPOSITORY = process.env['GITHUB_REPOSITORY']
+const GITHUB_API_URL = process.env['GITHUB_API_URL']
 
 const REPO_DIRECTORY = process.env['GITHUB_WORKSPACE']
 
@@ -56,6 +57,7 @@ export {
   GITHUB_SHA,
   GITHUB_REF,
   GITHUB_REPOSITORY,
+  GITHUB_API_URL,
   REPO_DIRECTORY,
   CONFIG_PATH,
   FILE_EXTENSIONS_TO_PROCESS,

--- a/src/github-api.ts
+++ b/src/github-api.ts
@@ -1,7 +1,7 @@
 import Octokit from '@octokit/rest'
 
-import { GITHUB_TOKEN } from './constants'
+import { GITHUB_TOKEN, GITHUB_API_URL } from './constants'
 
-const octokit = new Octokit({ auth: `token ${GITHUB_TOKEN}` })
+const octokit = new Octokit({ auth: `token ${GITHUB_TOKEN}`, baseUrl: `${GITHUB_API_URL}` })
 
 export default octokit


### PR DESCRIPTION
## What does this PR introduce?

Currently, only github.com API is supported, so it has been added to support github enterprise.

- add GITHUB_API_URL and pass it as baseURL


## Related issues
- closes #162 

## Reviewers

- @benschwarz for engineering review
- @thefoxis for content and copy review
