### PR TITLE
Remove mozjpeg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,16 +31,6 @@ RUN apt-get update \
   swig \
   gobject-introspection
 
-RUN cd /usr/local/src \
-  && aclocal \
-  && autoconf \
-  && autoheader \
-  && libtoolize \
-  && automake --add-missing \
-  && ./configure \
-  && make \
-  && make install
-
 # we must not use any packages which depend directly or indirectly on libjpeg,
 # since we want to use our own mozjpeg build
 RUN apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-ARG MOZJPEG_VERSION=3.3.1
 ARG VIPS_VERSION=8.10.1
 
-ARG MOZJPEG_URL=https://github.com/mozilla/mozjpeg/archive
 ARG VIPS_URL=https://github.com/libvips/libvips/releases/download
-
-# mozjpeg installs to /opt/mozjpeg ... we need that on PKG_CONFIG_PATH so
-# that libvips configure can find it
-ENV PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/opt/mozjpeg/lib64/pkgconfig
 
 # libvips installs to /usr/local by default .. /usr/local/bin is on the
 # default path in ubuntu, but /usr/local/lib is not
@@ -38,10 +32,6 @@ RUN apt-get update \
   gobject-introspection
 
 RUN cd /usr/local/src \
-  && wget ${MOZJPEG_URL}/v${MOZJPEG_VERSION}.tar.gz \
-  && tar xzf v${MOZJPEG_VERSION}.tar.gz
-
-RUN cd /usr/local/src/mozjpeg-${MOZJPEG_VERSION} \
   && aclocal \
   && autoconf \
   && autoheader \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Image Actions is a Github Action built by performance experts at [Calibre](https
 Image Actions offers:
 
 - **Fast, efficient and near-lossless compression**
-- Best image compression algorithms available ([mozjpeg](https://github.com/mozilla/mozjpeg) and [libvips](https://github.com/libvips/libvips))
+- Best image compression algorithms available ([libvips](https://github.com/libvips/libvips))
 - [Ease of customisation](#Configuration): use default settings or adapt to your needs
 - Running on demand or schedule
 - Supports GitHub Enterprise
@@ -313,7 +313,6 @@ Happy to hear you’re interested in contributing to Image Actions! Please find 
 #### Image compression tools:
 
 - [sharp](https://github.com/lovell/sharp)
-- [mozjpeg](https://github.com/mozilla/mozjpeg)
 - [libvips](https://github.com/libvips/libvips)
 
 ## 💼 License


### PR DESCRIPTION
A draft PR to see how I can progress with removing mozjpeg

This PR: 

- removes references to mozjpeg in the README
- removes mozjpeg in the Dockerfile

The docker command referenced in the CONTRIBUTING file is successfully running locally.

Tests also pass locally:
![CleanShot 2024-10-28 at 16 15 18](https://github.com/user-attachments/assets/671f1cad-8c46-45b8-9891-e978f946470f)
