### PR TITLE
adds a build step to make sure docker-compose is there

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,22 @@ env:
   IMAGE_NAME: image-actions
 
 jobs:
+  # Make sure we have docker-compose
+  prepare:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install docker-compose
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y docker-compose
   # Run tests.
   # See also https://docs.docker.com/docker-hub/builds/automated-testing/
   test:
+    # Ensure docker-compose exists before we run tests that depend on it.
+    needs: prepare
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
If merged, this PR adds a step in the github/workflows/build.yml file to check for installation of docker-compose.

Other PRs have failing Docker tests because it can't find `docker-compose` so I'm hoping this will remedy that until we move away from Docker. 

The part I'm not super sure about is if the `tests` step must "need" the `prepare` step. 

At any rate, it looks like it still can't find it, even though the `prepare` job runs correctly. :( 

![CleanShot 2024-10-28 at 16 43 41](https://github.com/user-attachments/assets/55d2eb4a-c8b9-470d-8ac4-38b631b040ce)
