### PR TITLE
⬆️ Use (newer) `docker compose` command in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Run tests
         run: |
           if [ -f docker-compose.test.yml ]; then
-            docker-compose --file docker-compose.test.yml build
-            docker-compose --file docker-compose.test.yml run test
+            docker compose --file docker-compose.test.yml build
+            docker compose --file docker-compose.test.yml run test
           else
             docker build . --file Dockerfile
           fi


### PR DESCRIPTION
In this PR:

- [x] Use `docker compose` (rather than `docker-compose` [which has been long deprecated](https://www.docker.com/blog/announcing-compose-v2-general-availability/). 

Refs:

- #288