### PR TITLE
Add `GITHUB_TOKEN` default value in `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,6 +3,10 @@ author: "Calibre"
 description: "Compresses Images for the Web"
 
 inputs:
+  GITHUB_TOKEN:
+    description: "The token that the action will use to create and update the pull request."
+    default: ${{ github.token }}
+
   jpegQuality:
     description: "JPEG quality level"
     required: false


### PR DESCRIPTION

## What does this PR introduce?

Add default value for the `GITHUB_TOKEN` field.

## Related issues

That's just a quality of life improvement, so we don't need to specify it by default.

