### PR TITLE
🚛 Use Node LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:lts-alpine
 
 RUN mkdir -p /usr/local/src/image-actions
 WORKDIR /usr/local/src/image-actions


### PR DESCRIPTION
In this PR:

- [x] Switch from versioned (22) Node, to LTS 

Previously we were using versioned Node in `Dockerfile`, with Dependabot running to upgrade versions (see #342 as an example). 

At the moment I don't want to use Node 24 (currently "current"), and always prefer to use an LTS release for longevity.