### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Docker
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/calibreapp/image-actions/security/code-scanning/5](https://github.com/calibreapp/image-actions/security/code-scanning/5)

To fix the problem, add an explicit `permissions` block specifying the minimal permissions needed by the jobs in the workflow. This can either be done at the top-level for the entire workflow, or on each job that requires special permissions. In this case, both the `test` and `push` jobs do not perform GitHub write operations (creating issues, PRs, etc.), so the minimal ideal permission is `contents: read`. You can place this block at the workflow root, just under `name: Docker`, or add it specifically to the relevant jobs. Adding at the workflow root is cleanest and applies least privilege everywhere unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
