### PR TITLE
Get all paginated files from the PR and add support for `minAbsChange`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,19 +110,26 @@ with:
 
 `compressOnly` accepts a Boolean value (true or false) and defaults to false.
 
-### Minimum percentage change
+### Minimum change
 
-By default, Image Actions commits optimised images if the new size is at least 5% smaller than the original one.
+By default, Image Actions commits optimised images if the new size satisfies the following conditions:
+- it's at least 5% smaller than the original
+- the reduction is at least 1 KB
 
 Use the `minPctChange` option to change the percentage. You might want to increase it to avoid consecutive
 compressions of the same webp images.
 
+Use the `minAbsChange` option to change the absolute amount in bytes. You might want to increase it to avoid
+consecutive compressions of small png images.
+
 ```yml
 with:
   minPctChange: '2.5'
+  minAbsChange: '10000'
 ```
 
 `minPctChange` accepts a numerical value represented as a string. `Default = '5'`.
+`minAbsChange` accepts a numerical value represented as a string. `Default = '1024'`.
 
 ### Compress on demand or on schedule
 

--- a/__tests__/get-changed-images_test.js
+++ b/__tests__/get-changed-images_test.js
@@ -20,6 +20,7 @@ vi.mock('@actions/github', () => ({
 }))
 vi.mock('../src/config.ts')
 
+const mockPaginate = vi.fn()
 const mockListFiles = vi.fn()
 const mockGetConfig = vi.fn()
 const mockOctokit = {
@@ -27,7 +28,8 @@ const mockOctokit = {
     pulls: {
       listFiles: mockListFiles
     }
-  }
+  },
+  paginate: mockPaginate
 }
 
 beforeEach(() => {
@@ -60,11 +62,11 @@ test('returns changed image files from PR', async () => {
     { filename: 'styles.css', status: 'added' } // Non-image file
   ]
 
-  mockListFiles.mockResolvedValue({ data: mockFiles })
+  mockPaginate.mockResolvedValue(mockFiles)
 
   const result = await getChangedImages()
 
-  expect(mockListFiles).toHaveBeenCalledWith({
+  expect(mockPaginate).toHaveBeenCalledWith(mockListFiles, {
     owner: 'testowner',
     repo: 'testrepo',
     pull_number: 123
@@ -84,7 +86,7 @@ test('returns empty array when no image files changed', async () => {
     { filename: 'styles.css', status: 'added' }
   ]
 
-  mockListFiles.mockResolvedValue({ data: mockFiles })
+  mockPaginate.mockResolvedValue(mockFiles)
 
   const result = await getChangedImages()
 
@@ -98,7 +100,7 @@ test('filters out removed image files', async () => {
     { filename: 'add-this.webp', status: 'added' }
   ]
 
-  mockListFiles.mockResolvedValue({ data: mockFiles })
+  mockPaginate.mockResolvedValue(mockFiles)
 
   const result = await getChangedImages()
 
@@ -117,7 +119,7 @@ test('handles supported image file extensions', async () => {
     { filename: 'avatar.svg', status: 'modified' } // Unsupported format
   ]
 
-  mockListFiles.mockResolvedValue({ data: mockFiles })
+  mockPaginate.mockResolvedValue(mockFiles)
 
   const result = await getChangedImages()
 
@@ -148,7 +150,7 @@ test('returns null when no PR context (for fallback)', async () => {
 })
 
 test('handles GitHub API errors gracefully', async () => {
-  mockListFiles.mockRejectedValue(new Error('GitHub API error'))
+  mockPaginate.mockRejectedValue(new Error('GitHub API error'))
 
   const result = await getChangedImages()
 
@@ -156,7 +158,7 @@ test('handles GitHub API errors gracefully', async () => {
 })
 
 test('handles empty file list from API', async () => {
-  mockListFiles.mockResolvedValue({ data: [] })
+  mockPaginate.mockResolvedValue([])
 
   const result = await getChangedImages()
 
@@ -171,7 +173,7 @@ test('filters out images in ignored paths', async () => {
     { filename: 'node_modules/lib/logo.png', status: 'modified' }
   ]
 
-  mockListFiles.mockResolvedValue({ data: mockFiles })
+  mockPaginate.mockResolvedValue(mockFiles)
   mockGetConfig.mockResolvedValue({
     ignorePaths: ['node_modules/**']
   })
@@ -190,7 +192,7 @@ test('handles multiple ignore paths', async () => {
     { filename: 'build/optimized.png', status: 'added' }
   ]
 
-  mockListFiles.mockResolvedValue({ data: mockFiles })
+  mockPaginate.mockResolvedValue(mockFiles)
   mockGetConfig.mockResolvedValue({
     ignorePaths: ['node_modules/**', 'temp/**', 'build/**']
   })
@@ -207,7 +209,7 @@ test('handles empty ignore paths', async () => {
     { filename: 'assets/image3.webp', status: 'modified' }
   ]
 
-  mockListFiles.mockResolvedValue({ data: mockFiles })
+  mockPaginate.mockResolvedValue(mockFiles)
   mockGetConfig.mockResolvedValue({
     ignorePaths: []
   })
@@ -229,7 +231,7 @@ test('ignores specific subdirectories correctly', async () => {
     { filename: 'public/favicon.png', status: 'added' }
   ]
 
-  mockListFiles.mockResolvedValue({ data: mockFiles })
+  mockPaginate.mockResolvedValue(mockFiles)
   mockGetConfig.mockResolvedValue({
     ignorePaths: ['docs/assets/**']
   })

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,11 @@ inputs:
     required: false
     default: "false"
 
+  minAbsChange:
+    description: "Minimun bytes reduction to be committed"
+    required: false
+    default: "1024"
+
   minPctChange:
     description: "Minimun percentage reduction to be committed"
     required: false

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ import {
   AVIF_QUALITY,
   IGNORE_PATHS,
   COMPRESS_ONLY,
+  MIN_ABS_CHANGE,
   MIN_PCT_CHANGE
 } from './constants.ts'
 
@@ -20,6 +21,7 @@ interface Config {
   webp: WebpOptions
   avif: AvifOptions
   ignorePaths: string[]
+  minAbsChange: number
   minPctChange: number
 }
 
@@ -43,6 +45,7 @@ const getConfig = async () => {
     },
     ignorePaths: IGNORE_PATHS,
     compressOnly: COMPRESS_ONLY,
+    minAbsChange: MIN_ABS_CHANGE,
     minPctChange: MIN_PCT_CHANGE
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,6 +17,7 @@ const IGNORE_PATHS = core.getInput('ignorePaths')
   ? core.getInput('ignorePaths').split(',')
   : ['node_modules/**']
 const COMPRESS_ONLY = core.getInput('compressOnly') === 'true'
+const MIN_ABS_CHANGE = parseInt(core.getInput('minAbsChange')) || 1024
 const MIN_PCT_CHANGE = parseFloat(core.getInput('minPctChange')) || 5
 
 const COMMITTER = {
@@ -55,5 +56,6 @@ export {
   AVIF_QUALITY,
   IGNORE_PATHS,
   COMPRESS_ONLY,
+  MIN_ABS_CHANGE,
   MIN_PCT_CHANGE
 }

--- a/src/get-changed-images.ts
+++ b/src/get-changed-images.ts
@@ -4,7 +4,7 @@ import { Octokit } from '@octokit/action'
 import { context } from '@actions/github'
 import * as core from '@actions/core'
 
-import { FILE_EXTENSIONS_TO_PROCESS, REPO_DIRECTORY } from './constants.ts'
+import { FILE_EXTENSIONS_TO_PROCESS } from './constants.ts'
 import getConfig from './config.ts'
 
 const getChangedImages = async (): Promise<string[] | null> => {

--- a/src/get-changed-images.ts
+++ b/src/get-changed-images.ts
@@ -22,7 +22,7 @@ const getChangedImages = async (): Promise<string[] | null> => {
 
     core.info(`Fetching changed files for PR #${pullNumber}…`)
 
-    const { data: files } = await api.rest.pulls.listFiles({
+    const files = await api.paginate(api.rest.pulls.listFiles, {
       owner,
       repo,
       pull_number: pullNumber

--- a/src/image-processing.ts
+++ b/src/image-processing.ts
@@ -11,6 +11,7 @@ import getRepositoryImages from './get-repository-images.ts'
 import {
   REPO_DIRECTORY,
   EXTENSION_TO_SHARP_FORMAT_MAPPING,
+  MIN_ABS_CHANGE,
   MIN_PCT_CHANGE
 } from './constants.ts'
 
@@ -83,8 +84,10 @@ const processImage = async (
     const name = path.relative(repoDir, imgPath)
     const relativeImagePath = path.relative(process.cwd(), imgPath)
     const afterStats = info.size
-    const percentChange = ((beforeStats - afterStats) / beforeStats) * 100
-    const compressionWasSignificant = percentChange >= MIN_PCT_CHANGE
+    const absoluteChange = beforeStats - afterStats
+    const percentChange = (absoluteChange / beforeStats) * 100
+    const compressionWasSignificant =
+      absoluteChange >= MIN_ABS_CHANGE && percentChange >= MIN_PCT_CHANGE
 
     const processedImage: ProcessedImage = {
       name,


### PR DESCRIPTION
## What does this PR introduce?
- get all paginated files from the PR
- add support for `minAbsChange`

## Related issues

- closes #368
- closes #431

## Reviewers

- @benschwarz for engineering review
- @thefoxis for content and copy review
